### PR TITLE
Feat/9

### DIFF
--- a/src/main/java/goormthonuniv/team_22_be/api/activity/controller/ActivityController.java
+++ b/src/main/java/goormthonuniv/team_22_be/api/activity/controller/ActivityController.java
@@ -1,0 +1,75 @@
+package goormthonuniv.team_22_be.api.activity.controller;
+
+import goormthonuniv.team_22_be.api.activity.service.ActivityService;
+import goormthonuniv.team_22_be.api.activity.dto.ActivityRequestDto;
+import goormthonuniv.team_22_be.api.activity.dto.ActivityResponseDto;
+import goormthonuniv.team_22_be.member.presentation.docs.ActivityApiDocs;
+import goormthonuniv.team_22_be.common.response.ApiResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+public class ActivityController implements ActivityApiDocs {
+
+    private final ActivityService activityService;
+
+    @Override
+    public ResponseEntity<ApiResult<?>> list(@PageableDefault(size = 10) Pageable pageable) {
+        var page = activityService.list(pageable);
+        return ResponseEntity.ok(ApiResult.ok(page));
+    }
+
+    @Override
+    public ResponseEntity<ApiResult<ActivityResponseDto>> get(Long id) {
+        var dto = activityService.get(id);
+        return ResponseEntity.ok(ApiResult.ok(dto));
+    }
+
+    @Override
+    public ResponseEntity<ApiResult<ActivityResponseDto>> create(ActivityRequestDto request) {
+        var dto = activityService.create(request);
+        return ResponseEntity.status(201).body(ApiResult.ok(dto));
+    }
+
+    @Override
+    public ResponseEntity<ApiResult<ActivityResponseDto>> update(Long id, ActivityRequestDto request) {
+        var dto = activityService.update(id, request);
+        return ResponseEntity.ok(ApiResult.ok(dto));
+    }
+
+    @Override
+    public ResponseEntity<ApiResult<Void>> delete(Long id) {
+        activityService.delete(id);
+        return ResponseEntity.ok(ApiResult.ok());
+    }
+
+    @Override
+    public ResponseEntity<ApiResult<Void>> like(Long id) {
+        activityService.like(id);
+        return ResponseEntity.ok(ApiResult.ok());
+    }
+
+    @Override
+    public ResponseEntity<ApiResult<Void>> unlike(Long id) {
+        activityService.unlike(id);
+        return ResponseEntity.ok(ApiResult.ok());
+    }
+
+    @Override
+    public ResponseEntity<ApiResult<Void>> apply(Long id) {
+        activityService.apply(id);
+        return ResponseEntity.ok(ApiResult.ok());
+    }
+
+    @Override
+    public ResponseEntity<ApiResult<Void>> cancelApply(Long id) {
+        activityService.cancelApply(id);
+        return ResponseEntity.ok(ApiResult.ok());
+    }
+}

--- a/src/main/java/goormthonuniv/team_22_be/api/activity/dto/ActivityListItemResponse.java
+++ b/src/main/java/goormthonuniv/team_22_be/api/activity/dto/ActivityListItemResponse.java
@@ -1,0 +1,44 @@
+package goormthonuniv.team_22_be.api.activity.dto;
+
+import goormthonuniv.team_22_be.api.activity.entity.Activity;
+import goormthonuniv.team_22_be.api.activity.entity.ActivityType;
+import goormthonuniv.team_22_be.api.activity.entity.RecruitStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record ActivityListItemResponse(
+        @Schema(description = "활동 ID")
+        Long id,
+
+        @Schema(description = "활동 유형")
+        ActivityType activityType,
+
+        @Schema(description = "제목")
+        String title,
+
+        @Schema(description = "장소")
+        String location,
+
+        @Schema(description = "찜 개수")
+        Long likes,
+
+        @Schema(description = "모집 상태")
+        RecruitStatus recruitStatus,
+
+        @Schema(description = "신청 마감일")
+        LocalDateTime applyEndAt
+
+) {
+    public static ActivityListItemResponse from(Activity activity) {
+        return new ActivityListItemResponse(
+                activity.getId(),
+                activity.getActivityType(),
+                activity.getTitle(),
+                activity.getLocation(),
+                activity.getLikes() != null ? activity.getLikes() : 0L,
+                activity.getRecruitStatus(),
+                activity.getApplyEndAt()
+        );
+    }
+}

--- a/src/main/java/goormthonuniv/team_22_be/api/activity/dto/ActivityRequestDto.java
+++ b/src/main/java/goormthonuniv/team_22_be/api/activity/dto/ActivityRequestDto.java
@@ -1,0 +1,38 @@
+package goormthonuniv.team_22_be.api.activity.dto;
+
+import goormthonuniv.team_22_be.api.activity.entity.ActivityType;
+import goormthonuniv.team_22_be.api.activity.entity.RecruitStatus;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDateTime;
+
+public record ActivityRequestDto(
+
+        @NotNull(message = "활동 유형은 필수입니다.")
+        ActivityType activityType,
+
+        @NotBlank(message = "제목은 필수입니다.")
+        @Size(max = 200, message = "제목은 최대 200자까지 입력 가능합니다.")
+        String title,
+
+        @NotBlank(message = "내용은 필수입니다.")
+        String content,
+
+        @NotBlank(message = "장소는 필수입니다.")
+        @Size(max = 200, message = "장소는 최대 200자까지 입력 가능합니다.")
+        String location,
+
+        @NotNull(message = "신청 시작일은 필수입니다.")
+        LocalDateTime applyStartAt,
+
+        @NotNull(message = "신청 마감일은 필수입니다.")
+        @Future(message = "마감일은 현재 시각 이후여야합니다.")
+        LocalDateTime applyEndAt,
+
+        @NotNull(message = "모집 상태는 필수입니다.")
+        RecruitStatus recruitStatus
+) {
+}

--- a/src/main/java/goormthonuniv/team_22_be/api/activity/dto/ActivityResponseDto.java
+++ b/src/main/java/goormthonuniv/team_22_be/api/activity/dto/ActivityResponseDto.java
@@ -1,0 +1,62 @@
+package goormthonuniv.team_22_be.api.activity.dto;
+
+import goormthonuniv.team_22_be.api.activity.entity.Activity;
+import goormthonuniv.team_22_be.api.activity.entity.ActivityType;
+import goormthonuniv.team_22_be.api.activity.entity.RecruitStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record ActivityResponseDto(
+        @Schema(description = "활동 ID")
+        Long id,
+
+        @Schema(description = "활동 유형")
+        ActivityType activityType,
+
+        @Schema(description = "제목")
+        String title,
+
+        @Schema(description = "내용")
+        String content,
+
+        @Schema(description = "장소")
+        String location,
+
+        @Schema(description = "찜 개수")
+        Long likes,
+
+        @Schema(description = "신청 시작일")
+        LocalDateTime applyStartAt,
+
+        @Schema(description = "신청 마감일")
+        LocalDateTime applyEndAt,
+
+        @Schema(description = "모집 상태")
+        RecruitStatus recruitStatus,
+
+        @Schema(description = "생성일시")
+        LocalDateTime createdAt,
+
+        @Schema(description = "수정일시")
+        LocalDateTime updatedAt
+
+) {
+    public static ActivityResponseDto from(Activity activity
+    ) {
+        return new ActivityResponseDto(
+                activity.getId(),
+                activity.getActivityType(),
+                activity.getTitle(),
+                activity.getContent(),
+                activity.getLocation(),
+                activity.getLikes() != null ? activity.getLikes() : 0L,
+                activity.getApplyStartAt(),
+                activity.getApplyEndAt(),
+                activity.getRecruitStatus(),
+                activity.getCreatedAt(),
+                activity.getUpdatedAt()
+        );
+    }
+
+}

--- a/src/main/java/goormthonuniv/team_22_be/api/activity/entity/Activity.java
+++ b/src/main/java/goormthonuniv/team_22_be/api/activity/entity/Activity.java
@@ -1,0 +1,79 @@
+package goormthonuniv.team_22_be.api.activity.entity;
+
+import goormthonuniv.team_22_be.common.utils.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "activities")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Activity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", columnDefinition = "BIGINT")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "activity_type", nullable = false, length = 20)
+    private ActivityType activityType;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Lob
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "location", nullable = false, length = 200)
+    private String location;
+
+    @Column(name = "likes", nullable = false)
+    private Long likes = 0L;
+
+    @Column(name = "apply_start_at", nullable = false)
+    private LocalDateTime applyStartAt;
+
+    @Column(name = "apply_end_at", nullable = false)
+    private LocalDateTime applyEndAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "recruit_status", nullable = false, length = 20)
+    private RecruitStatus recruitStatus;
+
+    @OneToMany(
+            mappedBy = "activity",
+            cascade = CascadeType.REMOVE,
+            orphanRemoval = true
+    )
+    private List<ActivityApplication> applicationList = new ArrayList<>();
+
+    @OneToMany(
+            mappedBy = "activity",
+            cascade = CascadeType.REMOVE,
+            orphanRemoval = true
+    )
+    private List<ActivityLike> likeList = new ArrayList<>();
+
+
+    /*
+    편의 메서드
+     */
+    public void increaseLikes() {
+        if(likes == null) likes = 0L;
+        likes++;
+    }
+
+    public void decreaseLikes() {
+        if(likes == null || likes == 0) return;
+        likes--;
+    }
+}

--- a/src/main/java/goormthonuniv/team_22_be/api/activity/entity/Activity.java
+++ b/src/main/java/goormthonuniv/team_22_be/api/activity/entity/Activity.java
@@ -76,4 +76,20 @@ public class Activity extends BaseTimeEntity {
         if(likes == null || likes == 0) return;
         likes--;
     }
+
+    /**
+     * 지금 시각 기준으로 신청 가능한지 여부를 반환
+     * - 모집 상태가 OPEN 이어야 함
+     * - 시작일이 있으면 now >= start
+     * - 마감일이 있으면 now <= end
+     */
+    public boolean isApplyOpenNow(LocalDateTime now) {
+        if (this.recruitStatus != RecruitStatus.OPEN) return false;
+
+        boolean afterStart = (applyStartAt == null) || !now.isBefore(applyStartAt);
+        boolean beforeEnd  = (applyEndAt   == null) || !now.isAfter(applyEndAt);
+
+        return afterStart && beforeEnd;
+    }
+
 }

--- a/src/main/java/goormthonuniv/team_22_be/api/activity/entity/Activity.java
+++ b/src/main/java/goormthonuniv/team_22_be/api/activity/entity/Activity.java
@@ -36,6 +36,7 @@ public class Activity extends BaseTimeEntity {
     @Column(name = "location", nullable = false, length = 200)
     private String location;
 
+    @Builder.Default
     @Column(name = "likes", nullable = false)
     private Long likes = 0L;
 

--- a/src/main/java/goormthonuniv/team_22_be/api/activity/entity/ActivityApplication.java
+++ b/src/main/java/goormthonuniv/team_22_be/api/activity/entity/ActivityApplication.java
@@ -1,0 +1,37 @@
+package goormthonuniv.team_22_be.api.activity.entity;
+
+import goormthonuniv.team_22_be.api.entity.Member;
+import goormthonuniv.team_22_be.common.utils.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+        name = "activity_applications",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"member_id", "activity_id"})
+        }
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ActivityApplication extends BaseTimeEntity {
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        @Column(name = "id", columnDefinition = "BIGINT")
+        private Long id;
+
+        @ManyToOne(fetch = FetchType.LAZY, optional = false)
+        @JoinColumn(name = "member_id", nullable = false)
+        private Member member;
+
+        @ManyToOne(fetch = FetchType.LAZY, optional = false)
+        @JoinColumn(name = "activity_id", nullable = false)
+        private Activity activity;
+
+        @Enumerated(EnumType.STRING)
+        @Column(name = "status", nullable = false, length = 20)
+        private ApplicationStatus status;
+}

--- a/src/main/java/goormthonuniv/team_22_be/api/activity/entity/ActivityLike.java
+++ b/src/main/java/goormthonuniv/team_22_be/api/activity/entity/ActivityLike.java
@@ -1,0 +1,33 @@
+package goormthonuniv.team_22_be.api.activity.entity;
+
+import goormthonuniv.team_22_be.api.entity.Member;
+import goormthonuniv.team_22_be.common.utils.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+        name = "activity_likes",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"member_id", "activity_id"})
+        }
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ActivityLike extends BaseTimeEntity {
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        @Column(name = "id", columnDefinition = "BIGINT")
+        private Long id;
+
+        @ManyToOne(fetch = FetchType.LAZY,optional = false)
+        @JoinColumn(name = "member_id", nullable = false)
+        private Member member;
+
+        @ManyToOne(fetch = FetchType.LAZY,optional = false)
+        @JoinColumn(name = "activity_id", nullable = false)
+        private Activity activity;
+}

--- a/src/main/java/goormthonuniv/team_22_be/api/activity/entity/ActivityType.java
+++ b/src/main/java/goormthonuniv/team_22_be/api/activity/entity/ActivityType.java
@@ -1,0 +1,5 @@
+package goormthonuniv.team_22_be.api.activity.entity;
+
+public enum ActivityType {
+    ALONE, TOGETHER
+}

--- a/src/main/java/goormthonuniv/team_22_be/api/activity/entity/ApplicationStatus.java
+++ b/src/main/java/goormthonuniv/team_22_be/api/activity/entity/ApplicationStatus.java
@@ -1,0 +1,5 @@
+package goormthonuniv.team_22_be.api.activity.entity;
+
+public enum ApplicationStatus {
+    APPLIED, APPROVED, REJECTED, CANCELLED;
+}

--- a/src/main/java/goormthonuniv/team_22_be/api/activity/entity/RecruitStatus.java
+++ b/src/main/java/goormthonuniv/team_22_be/api/activity/entity/RecruitStatus.java
@@ -1,0 +1,5 @@
+package goormthonuniv.team_22_be.api.activity.entity;
+
+public enum RecruitStatus {
+    OPEN, CLOSED, FINISHED
+}

--- a/src/main/java/goormthonuniv/team_22_be/api/activity/repository/ActivityApplicationRepository.java
+++ b/src/main/java/goormthonuniv/team_22_be/api/activity/repository/ActivityApplicationRepository.java
@@ -1,0 +1,20 @@
+package goormthonuniv.team_22_be.api.activity.repository;
+
+import goormthonuniv.team_22_be.api.activity.entity.ActivityApplication;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ActivityApplicationRepository extends JpaRepository<ActivityApplication, Long> {
+
+    /** 특정 회원이 특정 활동에 신청했는지 여부 (중복 신청 방지용) */
+    boolean existsByMember_IdAndActivity_Id(Long memberId, Long activityId);
+
+    /** 회원-활동 기준 단건 조회 (취소/상태 변경 용도) */
+    Optional<ActivityApplication> findByMember_IdAndActivity_Id(Long memberId, Long activityId);
+
+    /** 내 신청 목록 */
+    List<ActivityApplication> findAllByMember_Id(Long memberId);
+
+}

--- a/src/main/java/goormthonuniv/team_22_be/api/activity/repository/ActivityLikeRepository.java
+++ b/src/main/java/goormthonuniv/team_22_be/api/activity/repository/ActivityLikeRepository.java
@@ -1,0 +1,15 @@
+package goormthonuniv.team_22_be.api.activity.repository;
+
+import goormthonuniv.team_22_be.api.activity.entity.ActivityLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ActivityLikeRepository extends JpaRepository<ActivityLike, Long> {
+
+    /** 특정 회원이 특정 활동을 찜했는지 (중복 찜 방지) */
+    boolean existsByMember_IdAndActivity_Id(Long memberId, Long activityId);
+
+
+    /** 찜 해제 */
+    void deleteByMember_IdAndActivity_Id(Long memberId, Long activityId);
+
+}

--- a/src/main/java/goormthonuniv/team_22_be/api/activity/repository/ActivityRepository.java
+++ b/src/main/java/goormthonuniv/team_22_be/api/activity/repository/ActivityRepository.java
@@ -1,0 +1,26 @@
+package goormthonuniv.team_22_be.api.activity.repository;
+
+import goormthonuniv.team_22_be.api.activity.entity.Activity;
+import goormthonuniv.team_22_be.api.activity.entity.ActivityType;
+import goormthonuniv.team_22_be.api.activity.entity.RecruitStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface ActivityRepository extends JpaRepository<Activity, Long>, JpaSpecificationExecutor<Activity> {
+
+    /**
+     * 모집 상태(recruitStatus)별 활동 목록 조회
+     * ex) 현재 모집 중(OPEN), 모집 종료(CLOSED) 등
+     */
+    Page<Activity> findByRecruitStatus(RecruitStatus recruitStatus, Pageable pageable);
+
+    /**
+     * 활동 유형(activityType)별 목록 조회
+     * ALONE, TOGETHER 등
+     */
+    Page<Activity> findByActivityType(ActivityType type, Pageable pageable);
+
+
+}

--- a/src/main/java/goormthonuniv/team_22_be/api/activity/service/ActivityService.java
+++ b/src/main/java/goormthonuniv/team_22_be/api/activity/service/ActivityService.java
@@ -1,0 +1,20 @@
+package goormthonuniv.team_22_be.api.activity.service;
+
+import goormthonuniv.team_22_be.api.activity.dto.ActivityRequestDto;
+import goormthonuniv.team_22_be.api.activity.dto.ActivityResponseDto;
+import goormthonuniv.team_22_be.shared.dto.PageResponse;
+import org.springframework.data.domain.Pageable;
+
+public interface ActivityService {
+    PageResponse<?> list(Pageable pageable);
+    ActivityResponseDto get(Long id);
+    ActivityResponseDto create(ActivityRequestDto req);
+    ActivityResponseDto update(Long id, ActivityRequestDto req);
+    void delete(Long id);
+
+    void like(Long activityId);
+    void unlike(Long activityId);
+
+    void apply(Long activityId);
+    void cancelApply(Long activityId);
+}

--- a/src/main/java/goormthonuniv/team_22_be/api/activity/service/ActivityServiceImpl.java
+++ b/src/main/java/goormthonuniv/team_22_be/api/activity/service/ActivityServiceImpl.java
@@ -1,6 +1,4 @@
-package goormthonuniv.team_22_be.api.service;
-
-import goormthonuniv.team_22_be.api.activity.service.ActivityService;
+package goormthonuniv.team_22_be.api.activity.service;
 
 import goormthonuniv.team_22_be.api.activity.dto.ActivityListItemResponse;
 import goormthonuniv.team_22_be.api.activity.dto.ActivityRequestDto;

--- a/src/main/java/goormthonuniv/team_22_be/api/service/ActivityServiceImpl.java
+++ b/src/main/java/goormthonuniv/team_22_be/api/service/ActivityServiceImpl.java
@@ -1,0 +1,177 @@
+package goormthonuniv.team_22_be.api.service;
+
+import goormthonuniv.team_22_be.api.activity.service.ActivityService;
+
+import goormthonuniv.team_22_be.api.activity.dto.ActivityListItemResponse;
+import goormthonuniv.team_22_be.api.activity.dto.ActivityRequestDto;
+import goormthonuniv.team_22_be.api.activity.dto.ActivityResponseDto;
+import goormthonuniv.team_22_be.api.activity.entity.Activity;
+import goormthonuniv.team_22_be.api.activity.entity.ActivityApplication;
+import goormthonuniv.team_22_be.api.activity.entity.ActivityLike;
+import goormthonuniv.team_22_be.api.activity.entity.ApplicationStatus;
+import goormthonuniv.team_22_be.api.activity.repository.ActivityApplicationRepository;
+import goormthonuniv.team_22_be.api.activity.repository.ActivityLikeRepository;
+import goormthonuniv.team_22_be.api.activity.repository.ActivityRepository;
+import goormthonuniv.team_22_be.api.entity.Member;
+import goormthonuniv.team_22_be.common.exception.CustomException;
+import goormthonuniv.team_22_be.common.exception.ErrorCode;
+import goormthonuniv.team_22_be.common.security.AuthUtils;
+import goormthonuniv.team_22_be.shared.dto.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ActivityServiceImpl implements ActivityService {
+
+    private final ActivityRepository activityRepository;
+    private final ActivityApplicationRepository applicationRepository;
+    private final ActivityLikeRepository likeRepository;
+
+    /* ========= 목록 / 상세 ========= */
+
+    @Transactional(readOnly = true)
+    @Override
+    public PageResponse<?> list(Pageable pageable) {
+        var page = activityRepository.findAll(pageable).map(ActivityListItemResponse::from);
+        return PageResponse.of(page);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public ActivityResponseDto get(Long id) {
+        Activity a = activityRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "활동을 찾을 수 없습니다. id=" + id));
+        return ActivityResponseDto.from(a);
+    }
+
+    /* ========= 생성 / 수정 / 삭제 ========= */
+
+    @Override
+    public ActivityResponseDto create(ActivityRequestDto req) {
+        if (req.applyEndAt().isBefore(req.applyStartAt())) {
+            throw new CustomException(ErrorCode.BAD_REQUEST, "마감일이 시작일보다 빠를 수 없습니다.");
+        }
+
+        Activity a = Activity.builder()
+                .activityType(req.activityType())
+                .title(req.title())
+                .content(req.content())
+                .location(req.location())
+                .applyStartAt(req.applyStartAt())
+                .applyEndAt(req.applyEndAt())
+                .recruitStatus(req.recruitStatus())
+                .build();
+
+        return ActivityResponseDto.from(activityRepository.save(a));
+    }
+
+    @Override
+    public ActivityResponseDto update(Long id, ActivityRequestDto req) {
+        Activity a = activityRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "활동을 찾을 수 없습니다. id=" + id));
+
+        if (req.applyEndAt().isBefore(req.applyStartAt())) {
+            throw new CustomException(ErrorCode.BAD_REQUEST, "마감일이 시작일보다 빠를 수 없습니다.");
+        }
+
+        a.setActivityType(req.activityType());
+        a.setTitle(req.title());
+        a.setContent(req.content());
+        a.setLocation(req.location());
+        a.setApplyStartAt(req.applyStartAt());
+        a.setApplyEndAt(req.applyEndAt());
+        a.setRecruitStatus(req.recruitStatus());
+
+        return ActivityResponseDto.from(a);
+    }
+
+    @Override
+    public void delete(Long id) {
+        Activity a = activityRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "활동을 찾을 수 없습니다. id=" + id));
+        activityRepository.delete(a); // applications/likes 는 cascade=REMOVE 로 일괄 제거
+    }
+
+    /* ========= 찜 ========= */
+
+    @Override
+    public void like(Long activityId) {
+        Long memberId = AuthUtils.currentMemberIdOrThrow();
+
+        Activity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "활동을 찾을 수 없습니다. id=" + activityId));
+
+        if (likeRepository.existsByMember_IdAndActivity_Id(memberId, activityId)) {
+            return; // 이미 찜한 상태면 멱등 처리
+        }
+
+        ActivityLike like = ActivityLike.builder()
+                .member(Member.builder().id(memberId).build())
+                .activity(activity)
+                .build();
+
+        try {
+            likeRepository.save(like);
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(ErrorCode.CONFLICT, "이미 찜한 활동입니다.");
+        }
+    }
+
+    @Override
+    public void unlike(Long activityId) {
+        Long memberId = AuthUtils.currentMemberIdOrThrow();
+
+        if (!likeRepository.existsByMember_IdAndActivity_Id(memberId, activityId)) {
+            return; // 멱등
+        }
+
+        likeRepository.deleteByMember_IdAndActivity_Id(memberId, activityId);
+    }
+
+    /* ========= 신청 ========= */
+
+    @Override
+    public void apply(Long activityId) {
+        Long memberId = AuthUtils.currentMemberIdOrThrow();
+
+        Activity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "활동을 찾을 수 없습니다. id=" + activityId));
+
+        if (!activity.isApplyOpenNow(LocalDateTime.now())) {
+            throw new CustomException(ErrorCode.BAD_REQUEST, "신청 가능 기간이 아니거나 모집 중이 아닙니다.");
+        }
+
+        if (applicationRepository.existsByMember_IdAndActivity_Id(memberId, activityId)) {
+            throw new CustomException(ErrorCode.CONFLICT, "이미 신청한 활동입니다.");
+        }
+
+        ActivityApplication app = ActivityApplication.builder()
+                .member(Member.builder().id(memberId).build())
+                .activity(activity)
+                .status(ApplicationStatus.APPLIED)
+                .build();
+
+        try {
+            applicationRepository.save(app);
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(ErrorCode.CONFLICT, "이미 신청한 활동입니다.");
+        }
+    }
+
+    @Override
+    public void cancelApply(Long activityId) {
+        Long memberId = AuthUtils.currentMemberIdOrThrow();
+
+        ActivityApplication app = applicationRepository.findByMember_IdAndActivity_Id(memberId, activityId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "신청 내역이 없습니다."));
+
+        applicationRepository.delete(app); // soft-cancel 원하면 status 변경 로직으로 대체
+    }
+}

--- a/src/main/java/goormthonuniv/team_22_be/common/config/SecurityConfig.java
+++ b/src/main/java/goormthonuniv/team_22_be/common/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package goormthonuniv.team_22_be.common.config;
 
 import goormthonuniv.team_22_be.auth.JwtAuthFilter;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -13,50 +14,50 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
-//    @Bean
-//    SecurityFilterChain filterChain(HttpSecurity http,
-//                                    AuthenticationSuccessHandler successHandler,
-//                                    JwtAuthFilter jwtAuthFilter) throws Exception {
-//        http.csrf(csrf -> csrf.disable());
-//        http.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
-//
-//        http.authorizeHttpRequests(auth -> auth
-//                .requestMatchers("/", "/health", "/error", "/oauth2/**", "/login/**").permitAll()
-//                .requestMatchers("/api/secure/**").authenticated()
-//                .anyRequest().permitAll()
-//        );
-//
-//        http.oauth2Login(o -> o
-//                .loginPage("/oauth2/authorization/google")
-//                .successHandler(successHandler)
-//        );
-//
-//        // UsernamePasswordAuthenticationFilter 앞에 JWT 필터 삽입
-//        http.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
-//
-//        return http.build();
-//    }
+
+    private final JwtAuthFilter jwtAuthFilter;
+    private final AuthenticationSuccessHandler successHandler;
+
+    public SecurityConfig(JwtAuthFilter jwtAuthFilter, AuthenticationSuccessHandler successHandler) {
+        this.jwtAuthFilter = jwtAuthFilter;
+        this.successHandler = successHandler;
+    }
+
     @Bean
-    SecurityFilterChain filterChain(HttpSecurity http,
-                                    AuthenticationSuccessHandler successHandler) throws Exception {
-        http.csrf(csrf -> csrf.disable());
-        http.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+    SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .cors(cors -> {})
+                .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
-        http.authorizeHttpRequests(auth -> auth
-                .requestMatchers("/", "/health", "/error", "/oauth2/**", "/login/**").permitAll()
-                .requestMatchers(
-                        "/v3/api-docs/**",
-                        "/swagger-ui/**",
-                        "/swagger-ui.html"
-                ).permitAll()
-                .anyRequest().authenticated()
-        );
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/", "/health", "/error").permitAll()
+                        .requestMatchers(
+                                "/oauth2/**",
+                                "/login/**",
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/swagger-ui.html/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
 
-        http.oauth2Login(o -> o
-                .loginPage("/oauth2/authorization/google")
-                .successHandler(successHandler)
-        );
+                // 인증 실패 시 302 리다이렉트 대신 401 JSON
+                .exceptionHandling(ex -> ex.authenticationEntryPoint((req, res, e) -> {
+                    res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                    res.setContentType("application/json;charset=UTF-8");
+                    res.getWriter().write("{\"success\":false,\"code\":\"E401\",\"message\":\"Unauthorized\"}");
+                }))
 
+                // OAuth2 로그인 성공 시 JSON 토큰 내려주는 기존 핸들러
+                .oauth2Login(o -> o
+                        .loginPage("/oauth2/authorization/google")
+                        .successHandler(successHandler)
+                )
+
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
+
 }

--- a/src/main/java/goormthonuniv/team_22_be/common/exception/ErrorCode.java
+++ b/src/main/java/goormthonuniv/team_22_be/common/exception/ErrorCode.java
@@ -22,7 +22,10 @@ public enum ErrorCode {
 
     // 멤버/도메인
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M404", "회원 정보를 찾을 수 없습니다."),
-    MEMBER_DUPLICATED(HttpStatus.CONFLICT, "M409", "이미 가입된 계정입니다.");
+    MEMBER_DUPLICATED(HttpStatus.CONFLICT, "M409", "이미 가입된 계정입니다."),
+
+    // --- 추가 ---
+    CONFLICT(HttpStatus.CONFLICT, "E409", "리소스 충돌이 발생했습니다."); // ex. 중복 신청, 중복 찜
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/goormthonuniv/team_22_be/common/security/AuthUtils.java
+++ b/src/main/java/goormthonuniv/team_22_be/common/security/AuthUtils.java
@@ -1,0 +1,26 @@
+package goormthonuniv.team_22_be.common.security;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public final class AuthUtils {
+    private AuthUtils() {}
+
+    /** JwtAuthFilter에서 principal username을 "member:{id}" 로 넣었다는 전제 */
+    public static Long currentMemberIdOrThrow() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || auth.getName() == null) {
+            throw new IllegalStateException("인증 정보가 없습니다.");
+        }
+        String name = auth.getName(); // ex) "member:123"
+        if (!name.startsWith("member:")) {
+            throw new IllegalStateException("알 수 없는 인증 주체 형식: " + name);
+        }
+        try {
+            return Long.parseLong(name.substring("member:".length()));
+        } catch (NumberFormatException e) {
+            throw new IllegalStateException("회원 ID 파싱 실패: " + name);
+        }
+    }
+
+}

--- a/src/main/java/goormthonuniv/team_22_be/member/presentation/docs/ActivityApiDocs.java
+++ b/src/main/java/goormthonuniv/team_22_be/member/presentation/docs/ActivityApiDocs.java
@@ -1,0 +1,118 @@
+package goormthonuniv.team_22_be.member.presentation.docs;
+
+import goormthonuniv.team_22_be.api.activity.dto.ActivityRequestDto;
+import goormthonuniv.team_22_be.api.activity.dto.ActivityResponseDto;
+import goormthonuniv.team_22_be.common.exception.CustomException;
+import goormthonuniv.team_22_be.common.response.ApiResult;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Activity", description = "활동 조회/상세/생성/수정/삭제 및 신청/찜 API")
+@RequestMapping("/api/v1/activities")
+public interface ActivityApiDocs {
+
+    @Operation(
+            summary = "활동 목록 조회",
+            description = "페이지네이션으로 활동 목록을 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200",
+                            description = "조회 성공",
+                            content = @Content(schema = @Schema(implementation = ApiResult.class)))
+            }
+    )
+    @GetMapping
+    ResponseEntity<ApiResult<?>> list(@ParameterObject Pageable pageable);
+
+    @Operation(
+            summary = "활동 상세 조회",
+            description = "활동 단건 상세를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200",
+                            description = "조회 성공",
+                            content = @Content(schema = @Schema(implementation = ActivityResponseDto.class))),
+                    @ApiResponse(responseCode = "404",
+                            description = "존재하지 않는 활동",
+                            content = @Content(schema = @Schema(implementation = CustomException.class)))
+            }
+    )
+    @GetMapping("/{id}")
+    ResponseEntity<ApiResult<ActivityResponseDto>> get(@PathVariable Long id);
+
+    @Operation(
+            summary = "활동 생성",
+            description = "새로운 활동을 생성합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")},
+            responses = {
+                    @ApiResponse(responseCode = "201",
+                            description = "생성 성공",
+                            content = @Content(schema = @Schema(implementation = ActivityResponseDto.class))),
+                    @ApiResponse(responseCode = "400",
+                            description = "유효성 검증 실패",
+                            content = @Content(schema = @Schema(implementation = CustomException.class)))
+            }
+    )
+    @PostMapping
+    ResponseEntity<ApiResult<ActivityResponseDto>> create(@Valid @RequestBody ActivityRequestDto request);
+
+    @Operation(
+            summary = "활동 수정",
+            description = "기존 활동을 수정합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    @PutMapping("/{id}")
+    ResponseEntity<ApiResult<ActivityResponseDto>> update(@PathVariable Long id,
+                                                          @Valid @RequestBody ActivityRequestDto request);
+
+    @Operation(
+            summary = "활동 삭제",
+            description = "활동을 삭제합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    @DeleteMapping("/{id}")
+    ResponseEntity<ApiResult<Void>> delete(@PathVariable Long id);
+
+    // ----- 찜 / 찜 해제 -----
+
+    @Operation(
+            summary = "활동 찜",
+            description = "해당 활동을 찜합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    @PostMapping("/{id}/like")
+    ResponseEntity<ApiResult<Void>> like(@PathVariable Long id);
+
+    @Operation(
+            summary = "활동 찜 해제",
+            description = "해당 활동의 찜을 해제합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    @DeleteMapping("/{id}/like")
+    ResponseEntity<ApiResult<Void>> unlike(@PathVariable Long id);
+
+    // ----- 신청 / 신청 취소 -----
+
+    @Operation(
+            summary = "활동 신청",
+            description = "해당 활동을 신청합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    @PostMapping("/{id}/apply")
+    ResponseEntity<ApiResult<Void>> apply(@PathVariable Long id);
+
+    @Operation(
+            summary = "활동 신청 취소",
+            description = "해당 활동 신청을 취소합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    @DeleteMapping("/{id}/apply")
+    ResponseEntity<ApiResult<Void>> cancelApply(@PathVariable Long id);
+}

--- a/src/main/java/goormthonuniv/team_22_be/member/presentation/docs/ActivityApiDocs.java
+++ b/src/main/java/goormthonuniv/team_22_be/member/presentation/docs/ActivityApiDocs.java
@@ -50,7 +50,7 @@ public interface ActivityApiDocs {
     @Operation(
             summary = "활동 생성",
             description = "새로운 활동을 생성합니다.",
-            security = {@SecurityRequirement(name = "bearerAuth")},
+            security = {@SecurityRequirement(name = "BearerAuth")},
             responses = {
                     @ApiResponse(responseCode = "201",
                             description = "생성 성공",
@@ -66,7 +66,7 @@ public interface ActivityApiDocs {
     @Operation(
             summary = "활동 수정",
             description = "기존 활동을 수정합니다.",
-            security = {@SecurityRequirement(name = "bearerAuth")}
+            security = {@SecurityRequirement(name = "BearerAuth")}
     )
     @PutMapping("/{id}")
     ResponseEntity<ApiResult<ActivityResponseDto>> update(@PathVariable Long id,
@@ -75,7 +75,7 @@ public interface ActivityApiDocs {
     @Operation(
             summary = "활동 삭제",
             description = "활동을 삭제합니다.",
-            security = {@SecurityRequirement(name = "bearerAuth")}
+            security = {@SecurityRequirement(name = "BearerAuth")}
     )
     @DeleteMapping("/{id}")
     ResponseEntity<ApiResult<Void>> delete(@PathVariable Long id);
@@ -85,7 +85,7 @@ public interface ActivityApiDocs {
     @Operation(
             summary = "활동 찜",
             description = "해당 활동을 찜합니다.",
-            security = {@SecurityRequirement(name = "bearerAuth")}
+            security = {@SecurityRequirement(name = "BearerAuth")}
     )
     @PostMapping("/{id}/like")
     ResponseEntity<ApiResult<Void>> like(@PathVariable Long id);
@@ -93,7 +93,7 @@ public interface ActivityApiDocs {
     @Operation(
             summary = "활동 찜 해제",
             description = "해당 활동의 찜을 해제합니다.",
-            security = {@SecurityRequirement(name = "bearerAuth")}
+            security = {@SecurityRequirement(name = "BearerAuth")}
     )
     @DeleteMapping("/{id}/like")
     ResponseEntity<ApiResult<Void>> unlike(@PathVariable Long id);
@@ -103,7 +103,7 @@ public interface ActivityApiDocs {
     @Operation(
             summary = "활동 신청",
             description = "해당 활동을 신청합니다.",
-            security = {@SecurityRequirement(name = "bearerAuth")}
+            security = {@SecurityRequirement(name = "BearerAuth")}
     )
     @PostMapping("/{id}/apply")
     ResponseEntity<ApiResult<Void>> apply(@PathVariable Long id);
@@ -111,7 +111,7 @@ public interface ActivityApiDocs {
     @Operation(
             summary = "활동 신청 취소",
             description = "해당 활동 신청을 취소합니다.",
-            security = {@SecurityRequirement(name = "bearerAuth")}
+            security = {@SecurityRequirement(name = "BearerAuth")}
     )
     @DeleteMapping("/{id}/apply")
     ResponseEntity<ApiResult<Void>> cancelApply(@PathVariable Long id);

--- a/src/main/resources/liquibase/changelog/V003a_fix_activites_to_match_entity.sql
+++ b/src/main/resources/liquibase/changelog/V003a_fix_activites_to_match_entity.sql
@@ -1,0 +1,12 @@
+-- liquibase formatted sql
+-- changeset sanghyun:V003a-fix-activities runInTransaction:false
+
+-- title 50 → 200, content → TEXT, location 50 → 200, apply_* NOT NULL
+ALTER TABLE activities
+    MODIFY title         VARCHAR(200) NOT NULL,
+    MODIFY content       TEXT         NOT NULL,
+    MODIFY location      VARCHAR(200) NOT NULL,
+    MODIFY apply_start_at TIMESTAMP   NOT NULL,
+    MODIFY apply_end_at   TIMESTAMP   NOT NULL;
+
+CREATE INDEX idx_activities_apply_window ON activities(apply_start_at, apply_end_at);

--- a/src/main/resources/liquibase/changelog/V004a_fix_activity_applications_to_match_entity.sql
+++ b/src/main/resources/liquibase/changelog/V004a_fix_activity_applications_to_match_entity.sql
@@ -1,0 +1,22 @@
+-- liquibase formatted sql
+-- changeset sanghyun:V004a-fix-activity-applications runInTransaction:false
+
+
+-- 1) status 컬럼: ENUM + 기본값 보정
+ALTER TABLE activity_applications
+    MODIFY status ENUM('APPLIED','APPROVED','CANCELLED','REJECTED')
+    NOT NULL DEFAULT 'APPLIED';
+
+-- 2) 기존 FK 제거 (SHOW CREATE TABLE 결과의 실제 이름 사용)
+--    activity_id -> FKcdp49d64ohmi5sfut7vycr0a1
+--    member_id   -> FKjnypsygfcru2vdf714sr8hidk
+ALTER TABLE activity_applications
+DROP FOREIGN KEY FKcdp49d64ohmi5sfut7vycr0a1,
+  DROP FOREIGN KEY FKjnypsygfcru2vdf714sr8hidk;
+
+-- 3) 읽기 쉬운 이름으로 FK 재생성
+ALTER TABLE activity_applications
+    ADD CONSTRAINT fk_app_activity
+        FOREIGN KEY (activity_id) REFERENCES activities(id) ON DELETE CASCADE,
+  ADD CONSTRAINT fk_app_member
+    FOREIGN KEY (member_id)   REFERENCES members(id)   ON DELETE CASCADE;


### PR DESCRIPTION
## 👀 이슈
resolve #9 

## 📌 개요
활동(Activity) 도메인 CRUD, 신청/찜 기능을 구현하고, 관련 Liquibase 스키마와 엔티티 매핑을 보정했습니다.

## 👩‍💻 작업 사항
- 엔티티 정의 및 매핑
 (Activity / ActivityApplication / ActivityLike)
- Liquibase 보정 (V003a_fix_activites_to_match_entity.sql, V004a_fix_activity_applications_to_match_entity.sql)
-  Activity 관련서비스 구현 (스웨거)

## ✅ 참고 사항

공유할 내용 및 관련 스크린샷 등을 넣어 주세요